### PR TITLE
update app to make more obvious that it is for electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# h5-audio-conversion
+# electron-audio-conversion
 A promise-based library for loading audio files into HTML5 audio.  Uses the dataurl, id3 and mp3duration libraries. 
 
 # Installation
-`npm install h5-audio-conversion --save`
+`npm install electron-audio-conversion`
 
 # Usage
 This library comes with 4 functions:
@@ -13,9 +13,9 @@ This library comes with 4 functions:
 
 `createSongObject(filePath) ` -- Takes a filepath, creates a new object, calls `getSongDuration` and `getSongTags` and returns a promise with a song object that has the track, title, album and artist.  
 
-`createSongUri(filePath, mimetype) ` -- Takes a filepath and creates a dataUri for that file.  This dataUri is handed over to the HTML5 audio element to play the song.
+`createSongUri(filePath, mimetype) ` -- Takes a filepath and creates a dataUri for that file. This dataUri is handed over to the HTML5 audio element to play the song.
 
 In practice you'll likely only ever need `createSongObject` and `createSongUri` but you have access to the others if you need them.
 
 # Why?
-This library makes it easier to pull audio files from the local file system and play them in the browser.  It gets past the issues of the browser not having direct access to the filesystem.  We built this library to help with an Electron audio-player app and needed a way to create a playlist of song objects and then be able to make dataurl's on the fly for those songs as they're played.  
+This library makes it easier to pull audio files from the local file system and play them in the browser. We built this library to help with an Electron audio-player app and needed a way to create a playlist of song objects and then be able to make dataurl's on the fly for those songs as they're played.  

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "h5-audio-conversion",
+  "name": "electron-audio-conversion",
   "version": "0.1.0",
-  "description": "A promise-based library for loading audio files into HTML5 audio. Uses the dataurl, id3 and mp3duration libraries.",
+  "description": "A promise-based library for loading audio files into HTML5 audio element in Electron. Uses the dataurl, id3 and mp3duration libraries.",
   "main": "index.js",
   "scripts": {
     "test": "mocha",
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Jeff-Duke/h5-audio-conversion"
+    "url": "git+https://github.com/Jeff-Duke/electron-audio-conversion"
   },
   "keywords": [
     "html5-audio",
@@ -21,9 +21,9 @@
   "author": "Ben Godfrey and Jeff Duke",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Jeff-Duke/h5-audio-conversion/issues"
+    "url": "https://github.com/Jeff-Duke/electron-audio-conversion/issues"
   },
-  "homepage": "https://github.com/Jeff-Duke/h5-audio-conversion#readme",
+  "homepage": "https://github.com/Jeff-Duke/electron-audio-conversion#readme",
   "dependencies": {
     "dataurl": "^0.1.0",
     "id3js": "^1.1.3",


### PR DESCRIPTION
Update the readme and package.json files to rename the app to electron-audio-conversion.